### PR TITLE
Update Acorn modulefile to use spack-stack

### DIFF
--- a/modulefiles/ufs_acorn.intel.lua
+++ b/modulefiles/ufs_acorn.intel.lua
@@ -2,38 +2,22 @@ help([[
 Load environment to build UFS on Acorn with Intel compiler
 ]])
 
-PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
-load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
+prepend_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/spack-stack/spack-stack-1.3.0/envs/unified-env-compute/install/modulefiles/Core")
 
-intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-load(pathJoin("intel", intel_ver))
+load("stack-intel")
+load("stack-cray-mpich")
+load("stack-python")
 
-craype_ver=os.getenv("craype_ver") or "2.7.13"
-load(pathJoin("craype", craype_ver))
-
-cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.9"
-load(pathJoin("cray-mpich", cray_mpich_ver))
-
-cmake_ver=os.getenv("cmake_ver") or "3.20.2"
-load(pathJoin("cmake", cmake_ver))
-
-prepend_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/modulefiles/stack")
-
-hpc_ver=os.getenv("hpc_ver") or "1.2.0"
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "19.1.3.304"
-hpc_cray_mpich_ver=os.getenv("hpc_cray_mpich_ver") or "8.1.9"
-load(pathJoin("hpc", hpc_ver))
-load(pathJoin("hpc-intel", hpc_intel_ver))
-load(pathJoin("hpc-cray-mpich", hpc_cray_mpich_ver))
+--Avoid conflicts for several packages by unusing system spack installation:
+remove_path("MODULEPATH", "/apps/ops/prod/libs/modulefiles/compiler/intel/19.1.3.304")
+remove_path("MODULEPATH", "/apps/ops/prod/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.4")
+remove_path("MODULEPATH", "/apps/ops/prod/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
 
 load("ufs_common")
 
 prepend_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/UPP_IFI/modulefiles")
 load("ifi/20230118-intel-19.1.3.304")
 
-setenv("CC", "cc")
-setenv("CXX", "CC")
-setenv("FC", "ftn")
 setenv("CMAKE_Platform", "acorn")
 
 whatis("Description: UFS build environment")

--- a/modulefiles/ufs_common.lua
+++ b/modulefiles/ufs_common.lua
@@ -14,7 +14,7 @@ load(pathJoin("libpng", libpng_ver))
 hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
 load(pathJoin("hdf5", hdf5_ver))
 
-netcdf_c_ver=os.getenv("netcdf_ver") or "4.9.0"
+netcdf_c_ver=os.getenv("netcdf_ver") or "4.9.2"
 load(pathJoin("netcdf-c", netcdf_c_ver))
 
 netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.0"
@@ -50,7 +50,7 @@ load(pathJoin("sp", sp_ver))
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("w3emc", w3emc_ver))
 
-gftl_shared_ver=os.getenv("gftl_shared_ver") or "v1.5.0"
+gftl_shared_ver=os.getenv("gftl_shared_ver") or "1.5.0"
 load(pathJoin("gftl-shared", gftl_shared_ver))
 
 mapl_ver=os.getenv("mapl_ver") or "2.22.0-esmf-8.3.0b09"


### PR DESCRIPTION
This PR updates the Acorn modulefile to use the official spack-stack installation, and also updates the gftl-shared and netcdf-c version numbers in ufs_common.lua.