### PR TITLE
Update acorn modules

### DIFF
--- a/modulefiles/ufs_acorn.intel.lua
+++ b/modulefiles/ufs_acorn.intel.lua
@@ -8,10 +8,12 @@ load("stack-intel")
 load("stack-cray-mpich")
 load("stack-python")
 
---Avoid conflicts for several packages by unusing system spack installation:
+--Avoid production installations; use spack-stack only:
 remove_path("MODULEPATH", "/apps/ops/prod/libs/modulefiles/compiler/intel/19.1.3.304")
 remove_path("MODULEPATH", "/apps/ops/prod/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.4")
 remove_path("MODULEPATH", "/apps/ops/prod/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
+remove_path("MODULEPATH", "/apps/prod/lmodules/intel/19.1.3.304")
+remove_path("MODULEPATH", "/apps/prod/lmodules/INTEL_cray_mpich/19.1.3.304/cray-mpich/8.1.4")
 
 load("ufs_common")
 


### PR DESCRIPTION
There are a couple more modulepath tweaks needed to use spack-stack only.