### PR TITLE
Update Hercules EPIC accounts

### DIFF
--- a/modulefiles/ufs_hercules.gnu.lua
+++ b/modulefiles/ufs_hercules.gnu.lua
@@ -2,7 +2,7 @@ help([[
 loads UFS Model prerequisites for Hercules/GNU
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core")
 
 stack_gnu_ver=os.getenv("stack_gnu_ver") or "11.3.1"
 load(pathJoin("stack-gcc", stack_gnu_ver))

--- a/modulefiles/ufs_hercules.gnu.lua
+++ b/modulefiles/ufs_hercules.gnu.lua
@@ -2,7 +2,7 @@ help([[
 loads UFS Model prerequisites for Hercules/GNU
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1-hercules/envs/unified-env-v2/install/modulefiles/Core")
 
 stack_gnu_ver=os.getenv("stack_gnu_ver") or "11.3.1"
 load(pathJoin("stack-gcc", stack_gnu_ver))

--- a/modulefiles/ufs_hercules.gnu.lua
+++ b/modulefiles/ufs_hercules.gnu.lua
@@ -2,7 +2,7 @@ help([[
 loads UFS Model prerequisites for Hercules/GNU
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1-hercules/envs/unified-env-v2/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core")
 
 stack_gnu_ver=os.getenv("stack_gnu_ver") or "11.3.1"
 load(pathJoin("stack-gcc", stack_gnu_ver))

--- a/modulefiles/ufs_hercules.intel.lua
+++ b/modulefiles/ufs_hercules.intel.lua
@@ -2,7 +2,7 @@ help([[
 loads UFS Model prerequisites for Hercules/Intel
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1-hercules/envs/unified-env-v2/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.4.1/envs/unified-env/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.7.1"
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/ufs_hercules.intel.lua
+++ b/modulefiles/ufs_hercules.intel.lua
@@ -2,7 +2,7 @@ help([[
 loads UFS Model prerequisites for Hercules/Intel
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic-ps/role-epic-ps/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.7.1"
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/ufs_hercules.intel.lua
+++ b/modulefiles/ufs_hercules.intel.lua
@@ -2,7 +2,7 @@ help([[
 loads UFS Model prerequisites for Hercules/Intel
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.0-hercules/envs/unified-env-v2/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/spack-stack-1.4.1-hercules/envs/unified-env-v2/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.7.1"
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/tests/auto-jenkins/jobs/bl.py
+++ b/tests/auto-jenkins/jobs/bl.py
@@ -38,6 +38,11 @@ def set_directories(job_obj):
         blstore = '/work2/noaa/epic-ps/RT/NEMSfv3gfs'
         rtbldir = '/work/noaa/stmp/role-epic-ps/stmp/role-epic-ps/FV3_RT/'\
                  f'REGRESSION_TEST'
+    elif job_obj.machine == 'hercules':
+        workdir = '/work/noaa/epic/role-epic/autort/tests/auto/pr'
+        blstore = '/work2/noaa/epic/RT/NEMSfv3gfs'
+        rtbldir = '/work/noaa/stmp/role-epic/stmp/role-epic/FV3_RT/'\
+                 f'REGRESSION_TEST'  
     elif job_obj.machine == 'cheyenne':
         workdir = '/glade/scratch/epicufsrt/autort/jenkins/autort/pr'
         blstore = '/glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs'

--- a/tests/auto-jenkins/jobs/rt.py
+++ b/tests/auto-jenkins/jobs/rt.py
@@ -31,6 +31,8 @@ def set_directories(job_obj):
         workdir = '/lustre/f2/pdata/ncep/role.epic/autort/pr'
     elif job_obj.machine == 'orion':
         workdir = '/work/noaa/epic-ps/role-epic-ps/autort/tests/auto/pr'
+    elif job_obj.machine == 'hercules':
+        workdir = '/work/noaa/epic/role-epic/autort/tests/auto/pr'
     elif job_obj.machine == 'cheyenne':
         workdir = '/glade/scratch/epicufsrt/autort/jenkins/autort/pr'
     else:

--- a/tests/auto-jenkins/rt_auto_jenkins.py
+++ b/tests/auto-jenkins/rt_auto_jenkins.py
@@ -81,6 +81,8 @@ def delete_pr_dirs(each_pr, machine):
         workdir = '/lustre/f2/pdata/ncep/role.epic/autort/pr'
     elif machine == 'orion':
         workdir = '/work/noaa/epic-ps/role-epic-ps/autort/pr'
+    elif machine == 'hercules':
+        workdir = '/work/noaa/epic/role-epic/autort/pr'
     elif machine == 'cheyenne':
         workdir = '/glade/scratch/epicufsrt/autort/jenkins/autort/pr'
     else:
@@ -115,6 +117,8 @@ def delete_rt_dirs(in_dir, machine, workdir):
     elif machine == 'gaea':
         rt_dir = '/lustre/f2/scratch/role.epic/FV3_RT'
     elif machine == 'orion':
+        rt_dir = '/work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT'
+    elif machine == 'hercules':
         rt_dir = '/work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT'
     elif machine == 'cheyenne':
         rt_dir = '/glade/scratch/epicufsrt/FV3_RT'
@@ -294,6 +298,9 @@ def setup_env():
     elif bool(re.match(re.compile('Orion-login.+'), hostname)):
         machine = 'orion'
         os.environ['ACCNR'] = 'epic-ps'
+    elif bool(re.match(re.compile('Hercules-login.+'), hostname)):
+        machine = 'hercules'
+        os.environ['ACCNR'] = 'epic'
     elif bool(re.match(re.compile('cheyenne.+'), hostname)):
         machine = 'cheyenne'
         os.environ['ACCNR'] = 'SCSG0002'

--- a/tests/auto-jenkins/start_rt_auto_jenkins.sh
+++ b/tests/auto-jenkins/start_rt_auto_jenkins.sh
@@ -10,6 +10,9 @@ elif [[ $HOSTNAME == hecflow* ]]; then
 elif [[ $HOSTNAME == Orion-login-* ]]; then
   export PATH=/work/noaa/nems/emc.nemspara/soft/miniconda3/bin:$PATH
   export PYTHONPATH=/work/noaa/nems/emc.nemspara/soft/miniconda3/lib/python3.8/site-packages
+elif [[ $HOSTNAME == Hercules-login-* ]]; then
+  export PATH=/work/noaa/nems/emc.nemspara/soft/miniconda3/bin:$PATH
+  export PYTHONPATH=/work/noaa/nems/emc.nemspara/soft/miniconda3/lib/python3.8/site-packages  
 elif [[ $HOSTNAME == fe* ]]; then
   export PATH=/lfs4/HFIP/hfv3gfs/software/miniconda3/4.8.3/envs/ufs-weather-model/bin:/lfs4/HFIP/hfv3gfs/software/miniconda3/4.8.3/bin:$PATH
   export PYTHONPATH=/lfs4/HFIP/hfv3gfs/software/miniconda3/4.8.3/envs/ufs-weather-model/lib/python3.8/site-packages:/lfs4/HFIP/hfv3gfs/software/miniconda3/4.8.3/lib/python3.8/site-packages

--- a/tests/opnReqTest
+++ b/tests/opnReqTest
@@ -367,6 +367,32 @@ elif [[ $MACHINE_ID = orion ]]; then
   cp fv3_conf/fv3_slurm.IN_orion fv3_conf/fv3_slurm.IN
   cp fv3_conf/compile_slurm.IN_orion fv3_conf/compile_slurm.IN
 
+elif [[ $MACHINE_ID = hercules ]]; then
+
+  module load contrib rocoto/1.3.5
+  ROCOTORUN=$(which rocotorun)
+  ROCOTOSTAT=$(which rocotostat)
+  ROCOTOCOMPLETE=$(which rocotocomplete)
+  export PATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/bin:$PATH
+  export PYTHONPATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/lib/python3.9/site-packages
+
+  module use /work/noaa/epic/role-epic/spack-stack/modulefiles
+  module load ecflow/5.8.4-hercules
+  ECFLOW_START=/work/noaa/epic/role-epic/spack-stack/ecflow-5.8.4-hercules/bin/ecflow_start.sh
+  ECF_PORT=$(( $(id -u) + 1500 ))
+
+  QUEUE=windfall
+  COMPILE_QUEUE=windfall
+  PARTITION=hercules
+  dprefix=/work2/noaa/epic/${USER}
+  DISKNM=/work/noaa/nems/emc.nemspara/RT
+  STMP=$dprefix/stmp
+  PTMP=$dprefix/stmp
+
+  SCHEDULER=slurm
+  cp fv3_conf/fv3_slurm.IN_hercules fv3_conf/fv3_slurm.IN
+  cp fv3_conf/compile_slurm.IN_hercules fv3_conf/compile_slurm.IN
+
 elif [[ $MACHINE_ID = linux ]]; then
 
   PARTITION=
@@ -541,6 +567,8 @@ if [[ $ECFLOW == true ]]; then
 		EOF
   if [[ $MACHINE_ID == hera ]]; then
     QUEUE=batch
+  elif [[ $MACHINE_ID == hercules ]]; then
+    QUEUE=windfall
   elif [[ $MACHINE_ID == orion ]]; then
     QUEUE=batch
   else

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -265,15 +265,15 @@ elif [[ $MACHINE_ID = hercules ]]; then
   export PATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/bin:$PATH
   export PYTHONPATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/lib/python3.9/site-packages
 
-  module use /work/noaa/epic-ps/role-epic-ps/spack-stack/modulefiles
+  module use /work/noaa/epic/role-epic/spack-stack/modulefiles
   module load ecflow/5.8.4-hercules
-  ECFLOW_START=/work/noaa/epic-ps/role-epic-ps/spack-stack/ecflow-5.8.4-hercules/bin/ecflow_start.sh
+  ECFLOW_START=/work/noaa/epic/role-epic/spack-stack/ecflow-5.8.4-hercules/bin/ecflow_start.sh
   ECF_PORT=$(( $(id -u) + 1500 ))
 
   QUEUE=windfall
   COMPILE_QUEUE=windfall
   PARTITION=hercules
-  dprefix=/work2/noaa/epic-ps/${USER}
+  dprefix=/work2/noaa/epic/${USER}
   DISKNM=/work/noaa/nems/emc.nemspara/RT
   STMP=$dprefix/stmp
   PTMP=$dprefix/stmp

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -267,7 +267,7 @@ elif [[ $MACHINE_ID = hercules ]]; then
 
   module use /work/noaa/epic/role-epic/spack-stack/hercules/modulefiles
   module load ecflow/5.8.4-hercules
-  ECFLOW_START=/work/noaa/epic/role-epic/spack-stack/ecflow-5.8.4-hercules/bin/ecflow_start.sh
+  ECFLOW_START=/work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4/bin/ecflow_start.sh
   ECF_PORT=$(( $(id -u) + 1500 ))
 
   QUEUE=windfall
@@ -381,7 +381,7 @@ elif [[ $MACHINE_ID = expanse ]]; then
   SCHEDULER=slurm
   cp fv3_conf/fv3_slurm.IN_expanse fv3_conf/fv3_slurm.IN
 
- elif [[ $MACHINE_ID = noaacloud.* ]]; then
+ elif [[ $MACHINE_ID = noaacloud ]]; then
 
   module use /apps/modules/modulefiles
   module load rocoto/1.3.3

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -266,7 +266,7 @@ elif [[ $MACHINE_ID = hercules ]]; then
   export PYTHONPATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/lib/python3.9/site-packages
 
   module use /work/noaa/epic/role-epic/spack-stack/hercules/modulefiles
-  module load ecflow/5.8.4-hercules
+  module load ecflow/5.8.4
   ECFLOW_START=/work/noaa/epic/role-epic/spack-stack/hercules/ecflow-5.8.4/bin/ecflow_start.sh
   ECF_PORT=$(( $(id -u) + 1500 ))
 

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -265,7 +265,7 @@ elif [[ $MACHINE_ID = hercules ]]; then
   export PATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/bin:$PATH
   export PYTHONPATH=/apps/spack-managed/gcc-11.3.1/miniconda3-4.10.3-un3f2xdus7rbrzgso5ketsq4gp2iociv/lib/python3.9/site-packages
 
-  module use /work/noaa/epic/role-epic/spack-stack/modulefiles
+  module use /work/noaa/epic/role-epic/spack-stack/hercules/modulefiles
   module load ecflow/5.8.4-hercules
   ECFLOW_START=/work/noaa/epic/role-epic/spack-stack/ecflow-5.8.4-hercules/bin/ecflow_start.sh
   ECF_PORT=$(( $(id -u) + 1500 ))


### PR DESCRIPTION
## Description

Updating the Hercules EPIC accounts to /work/noaa/epic/role-epic from role-epic-ps

### Input data additions/changes
- [ ] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test.
- [ ] Changes are expected to the following tests:
<!-- Please insert what RT's change and why you expect them to change -->

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [ ] none

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [ ] Link PR's from all sub-components involved in section below
- [ ] Confirm reviews completed in ALL sub-component PR's
- [ ] Add all appropriate labels to this PR.
- [ ] Run full RT suite on either Hera/Cheyenne AND attach log to a PR comment.
- [ ] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: "- Depends on NOAA-EMC/fv3atm/pull/<pullrequest_number>"

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: "- Closes NOAA-EMC/fv3atm/issues/<issue_number>"

PLEASE MAKE SURE TO USE THE - with a space before the "Depends on" or "Closes" as they show up well on github.
-->

## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Jet
  - [ ] Gaea
  - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
