### PR TITLE
Load git module in rt.sh for S4

### DIFF
--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -378,6 +378,7 @@ elif [[ $MACHINE_ID = s4 ]]; then
 
   module use /data/prod/jedi/spack-stack/modulefiles
   module load ecflow/5.8.4
+  module load git/2.30.0
   ECFLOW_START=/data/prod/jedi/spack-stack/ecflow-5.8.4/bin/ecflow_start.sh 
   ECF_PORT=$(( $(id -u) + 1500 ))
 

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -369,14 +369,14 @@ elif [[ $MACHINE_ID = jet ]]; then
 elif [[ $MACHINE_ID = s4 ]]; then
 
   module load rocoto/1.3.2
-  module load ecflow/5.6.0
-  module load miniconda/3.8-s4
   ROCOTORUN=$(which rocotorun)
   ROCOTOSTAT=$(which rocotostat)
   ROCOTOCOMPLETE=$(which rocotocomplete)
   ROCOTO_SCHEDULER=slurm
 
+  module load git/2.30.0
   module use /data/prod/jedi/spack-stack/modulefiles
+  module load miniconda/3.9.12
   module load ecflow/5.8.4
   module load git/2.30.0
   ECFLOW_START=/data/prod/jedi/spack-stack/ecflow-5.8.4/bin/ecflow_start.sh 

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -378,7 +378,6 @@ elif [[ $MACHINE_ID = s4 ]]; then
   module use /data/prod/jedi/spack-stack/modulefiles
   module load miniconda/3.9.12
   module load ecflow/5.8.4
-  module load git/2.30.0
   ECFLOW_START=/data/prod/jedi/spack-stack/ecflow-5.8.4/bin/ecflow_start.sh 
   ECF_PORT=$(( $(id -u) + 1500 ))
 

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -97,11 +97,18 @@ cp ${PATHTR}/modulefiles/ufs_common*               ./modulefiles/.
 cp ${PATHRT}/module-setup.sh                       module-setup.sh
 
 # load nccmp module
-if [[ " hera orion gaea jet cheyenne acorn wcoss2 " =~ " $MACHINE_ID " ]]; then
+if [[ " s4 hera orion gaea jet cheyenne acorn wcoss2 " =~ " $MACHINE_ID " ]]; then
   if [[ " wcoss2 acorn " =~ " ${MACHINE_ID} " ]] ; then
     module load intel/19.1.3.304 netcdf/4.7.4
+    module load nccmp
+  elif [[ " s4 " =~ " ${MACHINE_ID} " ]] ; then
+    module use /data/prod/jedi/spack-stack/spack-stack-1.4.1/envs/ufs-pio-2.5.10/install/modulefiles/Core
+    module load stack-intel/2021.5.0 stack-intel-oneapi-mpi/2021.5.0
+    module load miniconda/3.9.12
+    module load nccmp/1.9.0.1
+  else
+    module load nccmp
   fi
-  module load nccmp
 fi
 
 SRCD="${PATHTR}"


### PR DESCRIPTION
This is needed for the `git submodule status` command later in the script, which will not run correctly with the system git.