### PR TITLE
correct gocart .rc files

### DIFF
--- a/tests/parm/gocart/gefs/CA2G_instance_CA.bc.rc
+++ b/tests/parm/gocart/gefs/CA2G_instance_CA.bc.rc
@@ -16,8 +16,16 @@ aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
 # Initially hydrophobic portion
 hydrophobic_fraction: 0.8
 
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs ! default value
+
 # Scavenging efficiency per bin [km-1] (NOT USED UNLESS RAS IS CALLED)
-fscav: 0.0  0.4 
+fscav: 0.0  0.4
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.0 1.0
+fwet_snow: 0.0 1.0
+fwet_rain: 0.0 1.0
 
 # Dry particle density [kg m-3]
 particle_density: 1800   1800

--- a/tests/parm/gocart/gefs/CA2G_instance_CA.br.rc
+++ b/tests/parm/gocart/gefs/CA2G_instance_CA.br.rc
@@ -21,8 +21,16 @@ pom_ca_ratio: 1.8
 # Initially hydrophobic portion
 hydrophobic_fraction: 0.5
 
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs ! default value
+
 # Scavenging efficiency per bin [km-1] (NOT USED UNLESS RAS IS CALLED)
 fscav: 0.0  0.4
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.0 0.4
+fwet_snow: 0.0 0.4
+fwet_rain: 0.0 0.4
 
 # particle radius
 particle_radius_microns: 0.35 0.35

--- a/tests/parm/gocart/gefs/CA2G_instance_CA.oc.rc
+++ b/tests/parm/gocart/gefs/CA2G_instance_CA.oc.rc
@@ -26,8 +26,16 @@ rhFlag: 0
 # Initially hydrophobic portion
 hydrophobic_fraction: 0.5
 
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs ! default value
+
 # Scavenging efficiency per bin [km-1] (NOT USED UNLESS RAS IS CALLED)
-fscav: 0.0  0.4 
+fscav: 0.0  0.4
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.0 1.0
+fwet_snow: 0.0 1.0
+fwet_rain: 0.0 1.0
 
 # Dry particle density [kg m-3]
 particle_density: 1800   1800

--- a/tests/parm/gocart/gefs/DU2G_instance_DU.rc
+++ b/tests/parm/gocart/gefs/DU2G_instance_DU.rc
@@ -19,9 +19,6 @@ particle_density: 2500. 2650. 2650. 2650. 2650.
 # Resolution dependent tuning constant for emissions (a,b,c,d,e,f) (Ginoux, K14)
 Ch_DU: 0.2 0.2 0.07 0.07 0.07 0.056
 
-# Scavenging efficiency per bin [km-1]
-fscav: 0.2  0.2  0.2  0.2  0.2   #
-
 # Molecular weight of species [kg mole-1]
 molecular_weight: 0.1  0.1  0.1  0.1  0.1
 
@@ -46,3 +43,18 @@ gamma: 1.0
 soil_moisture_factor: 1
 soil_drylimit_factor: 1
 vertical_to_horizontal_flux_ratio_limit: 2.e-04
+drag_partition_option: 2
+
+# clay fraction scaling factor
+soil_clay_factor: 1.0
+
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs ! default value
+
+# Scavenging efficiency per bin [km-1]
+fscav: 0.2  0.2  0.2  0.2  0.2
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.8 0.8 0.8 1.0 1.0
+fwet_snow: 0.8 0.8 0.8 1.0 1.0
+fwet_rain: 0.8 0.8 0.8 1.0 1.0

--- a/tests/parm/gocart/gefs/DU2G_instance_DU.rc
+++ b/tests/parm/gocart/gefs/DU2G_instance_DU.rc
@@ -43,7 +43,7 @@ gamma: 1.0
 soil_moisture_factor: 1
 soil_drylimit_factor: 1
 vertical_to_horizontal_flux_ratio_limit: 2.e-04
-drag_partition_option: 2
+drag_partition_option: 1
 
 # clay fraction scaling factor
 soil_clay_factor: 1.0

--- a/tests/parm/gocart/gefs/SS2G_instance_SS.rc
+++ b/tests/parm/gocart/gefs/SS2G_instance_SS.rc
@@ -13,8 +13,16 @@ radius_upper: 0.1 0.5 1.5 5.0 10.0
 
 particle_density: 2200. 2200. 2200. 2200. 2200.
 
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs ! default value
+
 # Scavenging efficiency per bin [km-1]
-fscav: 0.4  0.4  0.4  0.4  0.4 
+fscav: 0.4  0.4  0.4  0.4  0.4
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 1.0 1.0 1.0 1.0 1.0
+fwet_snow: 1.0 1.0 1.0 1.0 1.0
+fwet_rain: 1.0 1.0 1.0 1.0 1.0
 
 # Emissions methods and scaling
 emission_scheme: 3                                     # 1 for Gong 2003, 2 for ...


### PR DESCRIPTION
This pull request introduces a new wet removal scheme (`ufs`) across multiple configuration files in the `tests/parm/gocart/gefs` directory. The changes include adding parameters for rainout efficiency, scavenging efficiency, and other related settings for this scheme. Additionally, some files include new parameters for soil and drag partitioning.

### Additions for the new wet removal scheme:

* Added `wet_removal_scheme: ufs` as the default value in multiple configuration files (`CA2G_instance_CA.bc.rc`, `CA2G_instance_CA.br.rc`, `CA2G_instance_CA.oc.rc`, `DU2G_instance_DU.rc`, `SS2G_instance_SS.rc`). [[1]](diffhunk://#diff-ea303216a20afe113e63d07063eb650fc30bf01270356f624e4f8105f3e4be6cR19-R29) [[2]](diffhunk://#diff-4d2f235f23d8bb860b9134286f58da1f7dc7d1d84a88b80e474369b053fd358dR24-R34) [[3]](diffhunk://#diff-12b84338f133f35bb2534adc1f9ed444ed90b8b147cffaee35a143881c443e43R29-R39) [[4]](diffhunk://#diff-b93630aeeef8844669dcb25944710482c9f6097fee334e76c56e6472be99d6c5R46-R60) [[5]](diffhunk://#diff-5327b35c561150891075644431c698e8e82a6cba1690f4bace169a554ba97f08R16-R26)
* Introduced rainout efficiency parameters (`fwet_ice`, `fwet_snow`, `fwet_rain`) specific to the `ufs` scheme, with values varying across files. [[1]](diffhunk://#diff-ea303216a20afe113e63d07063eb650fc30bf01270356f624e4f8105f3e4be6cR19-R29) [[2]](diffhunk://#diff-4d2f235f23d8bb860b9134286f58da1f7dc7d1d84a88b80e474369b053fd358dR24-R34) [[3]](diffhunk://#diff-12b84338f133f35bb2534adc1f9ed444ed90b8b147cffaee35a143881c443e43R29-R39) [[4]](diffhunk://#diff-b93630aeeef8844669dcb25944710482c9f6097fee334e76c56e6472be99d6c5R46-R60) [[5]](diffhunk://#diff-5327b35c561150891075644431c698e8e82a6cba1690f4bace169a554ba97f08R16-R26)
* Re-added scavenging efficiency (`fscav`) parameters in `DU2G_instance_DU.rc` after they were previously removed.

### Additional parameter updates:

* Added `drag_partition_option: 2` and `soil_clay_factor: 1.0` to `DU2G_instance_DU.rc` for soil and drag partitioning adjustments.
* 

